### PR TITLE
Use Context and Markdown components for multiplying

### DIFF
--- a/component-library/components/Form/inputs/Text/index.tsx
+++ b/component-library/components/Form/inputs/Text/index.tsx
@@ -11,6 +11,7 @@ export function TextInput({
   placeholder,
   errors,
   list,
+  value,
 }: {
   name: string;
   id?: string;
@@ -20,6 +21,7 @@ export function TextInput({
   placeholder?: string;
   errors?: string[];
   list?: string;
+  value?: string;
 }) {
   return (
     <FieldWrapper label={label} id={id}>
@@ -33,6 +35,7 @@ export function TextInput({
         onChange={onChange}
         placeholder={placeholder}
         list={list}
+        value={value}
       />
     </FieldWrapper>
   );

--- a/component-library/components/Markdown/index.tsx
+++ b/component-library/components/Markdown/index.tsx
@@ -1,4 +1,4 @@
-import Markdown from "markdown-to-jsx";
+import Markdown, { MarkdownToJSX } from "markdown-to-jsx";
 import styles from "./styles.module.css";
 import clsx from "clsx";
 import Link from "next/link";
@@ -22,7 +22,13 @@ function MarkdownLink({
   );
 }
 
-export default function StyledMarkdown({ children }: { children: string }) {
+export default function StyledMarkdown({
+  children,
+  components,
+}: {
+  children: string;
+  components?: MarkdownToJSX.Overrides;
+}) {
   return (
     <Markdown
       className={clsx(styles.content)}
@@ -31,6 +37,7 @@ export default function StyledMarkdown({ children }: { children: string }) {
           a: {
             component: MarkdownLink,
           },
+          ...components,
         },
       }}
     >

--- a/component-library/components/Markdown/styles.module.css
+++ b/component-library/components/Markdown/styles.module.css
@@ -30,4 +30,7 @@
   a {
     text-decoration: underline;
   }
+  hr {
+    margin: 0.5rem 0;
+  }
 }

--- a/editor/cypress.config.ts
+++ b/editor/cypress.config.ts
@@ -27,5 +27,8 @@ export default defineConfig({
         },
       });
     },
+    retries: {
+      runMode: 2,
+    },
   },
 });

--- a/editor/cypress/e2e/new-recipe.cy.ts
+++ b/editor/cypress/e2e/new-recipe.cy.ts
@@ -56,11 +56,9 @@ describe("New Recipe View", () => {
           );
 
           // Verify first ingredient
-          cy.get('[name="ingredients[0].quantity"]').should("have.value", "1");
-          cy.get('[name="ingredients[0].unit"]').should("have.value", "cup");
           cy.get('[name="ingredients[0].ingredient"]').should(
             "have.value",
-            "water ((for the dashi packet))",
+            `<Multiplyable baseNumber="1" /> cup water ((for the dashi packet))`,
           );
 
           // Verify first instruction, which is a simple step

--- a/editor/cypress/e2e/new-recipe.cy.ts
+++ b/editor/cypress/e2e/new-recipe.cy.ts
@@ -52,7 +52,7 @@ describe("New Recipe View", () => {
           cy.get('[name="name"]').should("have.value", "Katsudon");
           cy.get('[name="description"]').should(
             "have.value",
-            "Katsudon is a Japanese pork cutlet rice bowl made with tonkatsu, eggs, and sautéed onions simmered in a sweet and savory sauce. It‘s a one-bowl wonder and true comfort food!",
+            "*Imported from [http://localhost:3000/uploads/katsudon.html](http://localhost:3000/uploads/katsudon.html)*\n\n---\n\nKatsudon is a Japanese pork cutlet rice bowl made with tonkatsu, eggs, and sautéed onions simmered in a sweet and savory sauce. It‘s a one-bowl wonder and true comfort food!",
           );
 
           // Verify first ingredient

--- a/editor/cypress/e2e/recipe.cy.ts
+++ b/editor/cypress/e2e/recipe.cy.ts
@@ -13,6 +13,12 @@ describe("Single Recipe View", () => {
       cy.findByText("Sign In");
     });
 
+    it("should be able to multiply ingredient amounts", () => {
+      cy.findByText("1 1/2 tsp salt");
+      cy.findByLabelText("Multiply").type("2");
+      cy.findByText("3 tsp salt");
+    });
+
     it("should be able to edit a recipe", () => {
       cy.findByText("Edit").click();
 

--- a/editor/cypress/e2e/recipe.cy.ts
+++ b/editor/cypress/e2e/recipe.cy.ts
@@ -26,7 +26,7 @@ describe("Single Recipe View", () => {
 
       cy.fillSignInForm();
 
-      cy.findByText("Editing Recipe: Recipe 6");
+      cy.findByText("Editing Recipe: Recipe 6", { timeout: 10000 });
 
       cy.findByText("Advanced").click();
 

--- a/editor/cypress/e2e/recipe.cy.ts
+++ b/editor/cypress/e2e/recipe.cy.ts
@@ -15,8 +15,10 @@ describe("Single Recipe View", () => {
 
     it("should be able to multiply ingredient amounts", () => {
       cy.findByText("1 1/2 tsp salt");
+      cy.findByText("Sprinkle 1/2 tsp salt in water");
       cy.findByLabelText("Multiply").type("2");
       cy.findByText("3 tsp salt");
+      cy.findByText("Sprinkle 1 tsp salt in water");
     });
 
     it("should be able to edit a recipe", () => {

--- a/editor/cypress/fixtures/test-content/two-pages/recipes/data/recipe-6/recipe.json
+++ b/editor/cypress/fixtures/test-content/two-pages/recipes/data/recipe-6/recipe.json
@@ -4,6 +4,10 @@
   "image": "recipe 6 test image.png",
   "date": 1701998172622,
   "ingredients": [
-    { "ingredient": "<Multiplyable baseNumber=\"1 1/2\" /> tsp salt" }
+    { "ingredient": "<Multiplyable baseNumber=\"1 1/2\" /> tsp salt" },
+    { "ingredient": "<Multiplyable baseNumber=\"1\" /> cup water" }
+  ],
+  "instructions": [
+    { "text": "Sprinkle <Multiplyable baseNumber=\"1/2\" /> tsp salt in water" }
   ]
 }

--- a/editor/cypress/fixtures/test-content/two-pages/recipes/data/recipe-6/recipe.json
+++ b/editor/cypress/fixtures/test-content/two-pages/recipes/data/recipe-6/recipe.json
@@ -2,5 +2,8 @@
   "name": "Recipe 6",
   "description": "",
   "image": "recipe 6 test image.png",
-  "date": 1701998172622
+  "date": 1701998172622,
+  "ingredients": [
+    { "ingredient": "<Multiplyable baseNumber=\"1 1/2\" /> tsp salt" }
+  ]
 }

--- a/editor/package.json
+++ b/editor/package.json
@@ -30,7 +30,6 @@
     "markdown-to-jsx": "^7.4.1",
     "next": "14.1.1",
     "next-auth": "^5.0.0-beta.9",
-    "parse-ingredient": "^1.2.0",
     "react": "^18",
     "react-dom": "^18",
     "recipes-collection": "^1.0.0",

--- a/editor/package.json
+++ b/editor/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.1.0",
     "component-library": "^1.0.0",
     "date-fns": "^3.3.1",
+    "entities": "^4.5.0",
     "flexsearch": "^0.7.43",
     "format-quantity": "^3.0.0",
     "fraction.js": "^4.3.7",

--- a/editor/src/app/(recipes)/recipe/[slug]/layout.tsx
+++ b/editor/src/app/(recipes)/recipe/[slug]/layout.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import getRecipes from "recipes-collection/controller/data/readIndex";
 import { MultiplierProvider } from "recipes-collection/components/View/Multiplier/Provider";
 
 export default function RecipeViewLayout({
@@ -8,9 +7,4 @@ export default function RecipeViewLayout({
   children: ReactNode;
 }) {
   return <MultiplierProvider>{children}</MultiplierProvider>;
-}
-
-export async function generateStaticParams() {
-  const { recipes } = await getRecipes();
-  return recipes.map(({ slug }) => ({ slug }));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       date-fns:
         specifier: ^3.3.1
         version: 3.3.1
+      entities:
+        specifier: ^4.5.0
+        version: 4.5.0
       flexsearch:
         specifier: ^0.7.43
         version: 0.7.43

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       next-auth:
         specifier: ^5.0.0-beta.9
         version: 5.0.0-beta.9(next@14.1.1)(react@18.2.0)
-      parse-ingredient:
-        specifier: ^1.2.0
-        version: 1.2.0
       react:
         specifier: ^18
         version: 18.2.0
@@ -156,9 +153,6 @@ importers:
       next:
         specifier: 14.1.1
         version: 14.1.1(react-dom@18.2.0)(react@18.2.0)
-      parse-ingredient:
-        specifier: ^1.2.0
-        version: 1.2.0
       plaiceholder:
         specifier: ^3.0.0
         version: 3.0.0(sharp@0.33.2)
@@ -213,9 +207,6 @@ importers:
       next:
         specifier: 14.1.1
         version: 14.1.1(react-dom@18.2.0)(react@18.2.0)
-      parse-ingredient:
-        specifier: ^1.2.0
-        version: 1.2.0
       react:
         specifier: ^18
         version: 18.2.0
@@ -8264,11 +8255,6 @@ packages:
       boolbase: 1.0.0
     dev: false
 
-  /numeric-quantity@2.0.1:
-    resolution: {integrity: sha512-+Bt2X6YxM5bg8XIBl76NVeG2eL0Y5VQRoyz6GLYrZXW/TDh7We+tGeX4/WZWhaVGOg5ZjNBEOZt9a86slMhOJA==}
-    engines: {node: '>=16'}
-    dev: false
-
   /oauth4webapi@2.10.3:
     resolution: {integrity: sha512-9FkXEXfzVKzH63GUOZz1zMr3wBaICSzk6DLXx+CGdrQ10ItNk2ePWzYYc1fdmKq1ayGFb2aX97sRCoZ2s0mkDw==}
     dev: false
@@ -8662,13 +8648,6 @@ packages:
   /parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
     engines: {node: '>=14'}
-    dev: false
-
-  /parse-ingredient@1.2.0:
-    resolution: {integrity: sha512-3xaNV8fBhcyOOuTV9pIBV6/BGXcJzacZfwkEKaamf1HH4uHStOx8hiRhpLGr/ruQXf1bkt4gRfFo52LxDsj9Zw==}
-    engines: {node: '>=10'}
-    dependencies:
-      numeric-quantity: 2.0.1
     dev: false
 
   /parse-json@5.2.0:

--- a/recipes-collection/components/Form/Ingredients/index.tsx
+++ b/recipes-collection/components/Form/Ingredients/index.tsx
@@ -2,7 +2,10 @@ import { RecipeFormErrors } from "../../../controller/formState";
 import { Ingredient } from "../../../controller/types";
 import { createIngredients } from "../../../util/parseIngredients";
 import { Button } from "component-library/components/Button";
-import { FieldWrapper, baseInputStyle } from "component-library/components/Form";
+import {
+  FieldWrapper,
+  baseInputStyle,
+} from "component-library/components/Form";
 import {
   InputListControls,
   useKeyList,
@@ -58,14 +61,6 @@ export function IngredientsListInput({
           return (
             <li key={key} className="flex flex-col my-1">
               <div>
-                <TextInput
-                  name={`${itemKey}.quantity`}
-                  defaultValue={defaultValue?.quantity}
-                />
-                <TextInput
-                  name={`${itemKey}.unit`}
-                  defaultValue={defaultValue?.unit}
-                />
                 <TextInput
                   name={`${itemKey}.ingredient`}
                   defaultValue={defaultValue?.ingredient}

--- a/recipes-collection/components/View/Instructions/index.tsx
+++ b/recipes-collection/components/View/Instructions/index.tsx
@@ -35,7 +35,9 @@ export const InstructionEntryView = ({
     return (
       <li className="my-3">
         {name && <h3 className={stepHeadingStyle}>{name}</h3>}
-        <Markdown components={{ Multiplyable }}>{text}</Markdown>
+        <Markdown components={{ Multiplyable: { component: Multiplyable } }}>
+          {text}
+        </Markdown>
       </li>
     );
   }

--- a/recipes-collection/components/View/Instructions/index.tsx
+++ b/recipes-collection/components/View/Instructions/index.tsx
@@ -1,6 +1,7 @@
 import { InstructionEntry } from "../../../controller/types";
 
 import Markdown from "component-library/components/Markdown";
+import { Multiplyable } from "../Multiplier/Multiplyable";
 
 const stepHeadingStyle = "text-lg font-bold my-2 border-b border-white";
 const childHeadingStyle = "text-base font-bold my-1 border-b border-white";
@@ -19,7 +20,11 @@ export const InstructionEntryView = ({
           {instructions.map(({ name, text }, i) => (
             <li key={i} className="my-2">
               {name && <h4 className={childHeadingStyle}>{name}</h4>}
-              <Markdown>{text}</Markdown>
+              <Markdown
+                components={{ Multiplyable: { component: Multiplyable } }}
+              >
+                {text}
+              </Markdown>
             </li>
           ))}
         </ol>
@@ -30,7 +35,7 @@ export const InstructionEntryView = ({
     return (
       <li className="my-3">
         {name && <h3 className={stepHeadingStyle}>{name}</h3>}
-        <Markdown>{text}</Markdown>
+        <Markdown components={{ Multiplyable }}>{text}</Markdown>
       </li>
     );
   }

--- a/recipes-collection/components/View/Multiplier/Multiplyable/index.tsx
+++ b/recipes-collection/components/View/Multiplier/Multiplyable/index.tsx
@@ -1,0 +1,28 @@
+"use client";
+import Fraction from "fraction.js";
+import { useMultiplier } from "../Provider";
+import { useMemo } from "react";
+
+function getFraction(quantity: string | number | undefined) {
+  if (quantity) {
+    try {
+      return new Fraction(quantity);
+    } catch (e) {
+      console.error(`Given quantity ${quantity} couldn't be parsed!`);
+    }
+  }
+  return undefined;
+}
+
+export function Multiplyable({ baseNumber }: { baseNumber: string | number }) {
+  const input = useMemo(() => getFraction(baseNumber), [baseNumber]);
+  const [{ multiplier }] = useMultiplier();
+
+  return (
+    <>
+      {multiplier && input
+        ? multiplier.mul(input).toFraction(true)
+        : input?.toFraction(true)}
+    </>
+  );
+}

--- a/recipes-collection/components/View/Multiplier/Provider.tsx
+++ b/recipes-collection/components/View/Multiplier/Provider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { ReactNode, Reducer, useReducer } from "react";
+import Fraction from "fraction.js";
+
+interface MultiplierState {
+  multiplier?: Fraction;
+  input?: string;
+}
+
+const MultiplierContext = React.createContext<
+  [MultiplierState, React.Dispatch<string>] | undefined
+>(undefined);
+
+const multiplierInputReducer: Reducer<MultiplierState, string> = (
+  state,
+  input,
+) => {
+  if (input === state.input) {
+    return state;
+  }
+  if (!input || input === "1") {
+    return { multiplier: undefined, input };
+  }
+  try {
+    const multiplier = new Fraction(input);
+    return { multiplier, input };
+  } catch (e) {
+    return state;
+  }
+};
+
+export function MultiplierProvider({ children }: { children: ReactNode }) {
+  const [multiplierState, setMultiplier] = useReducer(
+    multiplierInputReducer,
+    {},
+  );
+
+  return (
+    <MultiplierContext.Provider value={[multiplierState, setMultiplier]}>
+      {children}
+    </MultiplierContext.Provider>
+  );
+}
+
+export function useMultiplier() {
+  const context = React.useContext(MultiplierContext);
+  if (context === undefined) {
+    throw new Error("useMultiplier must be used within a MultiplierProvider");
+  }
+  return context;
+}

--- a/recipes-collection/components/View/Multiplier/index.tsx
+++ b/recipes-collection/components/View/Multiplier/index.tsx
@@ -70,10 +70,10 @@ export function MultiplyingView({ recipe }: { recipe: Recipe }) {
             id="multiplier"
             name="multiplier"
             label="Multiply"
+            value={input || ""}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               setMultiplier(e.target.value);
             }}
-            value={input}
           />
         </InfoCard>
       </label>

--- a/recipes-collection/components/View/Multiplier/index.tsx
+++ b/recipes-collection/components/View/Multiplier/index.tsx
@@ -2,99 +2,60 @@
 
 import React, { ChangeEvent, Reducer, useMemo, useReducer } from "react";
 
-import Fraction from "fraction.js";
-
 import { TextInput } from "component-library/components/Form/inputs/Text";
 import { Ingredient, Recipe } from "../../../controller/types";
 import { InfoCard } from "../shared";
 import { useMultiplier } from "./Provider";
+import StyledMarkdown from "component-library/components/Markdown";
+import { Multiplyable } from "./Multiplyable";
+import { Button } from "component-library/components/Button";
 
-function getFraction(quantity: string | undefined) {
-  if (quantity) {
-    try {
-      return new Fraction(quantity);
-    } catch (e) {
-      console.error(`Given quantity ${quantity} couldn't be parsed!`);
-    }
-  }
-  return undefined;
-}
-
-export const IngredientView = ({
-  ingredient,
-  quantity,
-  unit,
-  multiplier,
-  note,
-}: {
-  ingredient?: string;
-  quantity?: string;
-  unit?: string;
-  note?: string;
-  multiplier?: Fraction;
-}) => {
-  const parsedQuantity = useMemo(() => getFraction(quantity), [quantity]);
-  const multipliedQuantity =
-    parsedQuantity && multiplier && !multiplier.equals(1)
-      ? parsedQuantity.mul(multiplier)
-      : parsedQuantity;
+export const IngredientItem = ({ ingredient }: { ingredient?: string }) => {
   return (
     <li>
-      <div>
-        <label>
-          <input
-            type="checkbox"
-            className="peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
-          />{" "}
-          {multipliedQuantity && (
-            <span>{multipliedQuantity.toFraction(true)}</span>
-          )}{" "}
-          {unit && <span>{unit}</span>} <span>{ingredient}</span>
-          {note && (
-            <span>
-              , <span>{note}</span>
-            </span>
-          )}
-        </label>
-      </div>
+      <label>
+        <input
+          type="checkbox"
+          className="peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+        />{" "}
+        {ingredient && (
+          <StyledMarkdown components={{ Multiplyable }}>
+            {ingredient}
+          </StyledMarkdown>
+        )}
+      </label>
     </li>
   );
 };
 
 export const Ingredients = ({
   ingredients,
-  multiplier,
 }: {
   ingredients?: Ingredient[];
-  multiplier?: Fraction;
 }) => {
   return (
-    <>
+    <form>
       {ingredients && (
         <div>
           <h2 className="text-lg font-bold my-3">Ingredients</h2>
           <ul>
-            {ingredients.map(({ ingredient, note, quantity, unit }, i) => (
-              <IngredientView
-                key={i}
-                ingredient={ingredient}
-                note={note}
-                quantity={quantity}
-                unit={unit}
-                multiplier={multiplier}
-              />
+            {ingredients.map(({ ingredient }, i) => (
+              <IngredientItem key={i} ingredient={ingredient} />
             ))}
           </ul>
         </div>
       )}
-    </>
+      <Button className="mt-2" type="reset">
+        Reset
+      </Button>
+    </form>
   );
 };
 
 export function MultiplyingView({ recipe }: { recipe: Recipe }) {
   const { servings, servingSize, ingredients } = recipe;
 
-  const [{ multiplier }, setMultiplier] = useMultiplier();
+  const [{ multiplier, input }, setMultiplier] = useMultiplier();
 
   const multipliedServings =
     multiplier && servings
@@ -112,11 +73,12 @@ export function MultiplyingView({ recipe }: { recipe: Recipe }) {
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               setMultiplier(e.target.value);
             }}
+            value={input}
           />
         </InfoCard>
       </label>
       <div className="my-3 marker:text-sm">
-        <Ingredients ingredients={ingredients} multiplier={multiplier} />
+        <Ingredients ingredients={ingredients} />
       </div>
       <div className="m-2 flex flex-row flex-wrap items-center justify-center">
         {multipliedServings && (

--- a/recipes-collection/components/View/Multiplier/index.tsx
+++ b/recipes-collection/components/View/Multiplier/index.tsx
@@ -7,6 +7,7 @@ import Fraction from "fraction.js";
 import { TextInput } from "component-library/components/Form/inputs/Text";
 import { Ingredient, Recipe } from "../../../controller/types";
 import { InfoCard } from "../shared";
+import { useMultiplier } from "./Provider";
 
 function getFraction(quantity: string | undefined) {
   if (quantity) {
@@ -60,24 +61,6 @@ export const IngredientView = ({
   );
 };
 
-const fractionInputReducer: Reducer<
-  { fraction?: Fraction; input?: string },
-  string
-> = (state, input) => {
-  if (input === state.input) {
-    return state;
-  }
-  if (!input || input === "1") {
-    return { fraction: undefined, input };
-  }
-  try {
-    const fraction = new Fraction(input);
-    return { fraction, input };
-  } catch (e) {
-    return state;
-  }
-};
-
 export const Ingredients = ({
   ingredients,
   multiplier,
@@ -111,10 +94,7 @@ export const Ingredients = ({
 export function MultiplyingView({ recipe }: { recipe: Recipe }) {
   const { servings, servingSize, ingredients } = recipe;
 
-  const [{ fraction: multiplier }, setMultiplier] = useReducer(
-    fractionInputReducer,
-    {},
-  );
+  const [{ multiplier }, setMultiplier] = useMultiplier();
 
   const multipliedServings =
     multiplier && servings

--- a/recipes-collection/controller/buildIndexValue.ts
+++ b/recipes-collection/controller/buildIndexValue.ts
@@ -7,8 +7,6 @@ export default function buildRecipeIndexValue(
   return {
     name,
     image,
-    ingredients: ingredients?.map(({ quantity, unit, ingredient }) =>
-      [quantity, unit, ingredient].join(" "),
-    ),
+    ingredients: ingredients?.map(({ ingredient }) => ingredient),
   };
 }

--- a/recipes-collection/controller/parseFormData.ts
+++ b/recipes-collection/controller/parseFormData.ts
@@ -26,9 +26,6 @@ const RecipeFormSchema = z.object({
     .array(
       z.object({
         ingredient: z.string(),
-        quantity: z.string().optional(),
-        unit: z.string().optional(),
-        note: z.string().optional(),
       }),
     )
     .optional(),

--- a/recipes-collection/controller/types.ts
+++ b/recipes-collection/controller/types.ts
@@ -1,8 +1,5 @@
 export type Ingredient = {
   ingredient: string;
-  unit?: string;
-  quantity?: string;
-  note?: string;
 };
 
 export interface Instruction {

--- a/recipes-collection/package.json
+++ b/recipes-collection/package.json
@@ -16,7 +16,6 @@
     "fraction.js": "^4.3.7",
     "lodash": "^4.17.21",
     "next": "14.1.1",
-    "parse-ingredient": "^1.2.0",
     "plaiceholder": "^3.0.0",
     "react": "^18",
     "sharp": "0.33.2",

--- a/recipes-collection/util/importRecipeData.ts
+++ b/recipes-collection/util/importRecipeData.ts
@@ -1,3 +1,4 @@
+import { decodeHTML } from "entities";
 import { Instruction, InstructionGroup, Recipe } from "../controller/types";
 import { createIngredients } from "./parseIngredients";
 
@@ -64,8 +65,8 @@ function createStep({
   text?: string;
 }): Instruction {
   return {
-    name: name === text ? undefined : name,
-    text,
+    name: name && (name === text ? undefined : decodeHTML(name)),
+    text: decodeHTML(text),
   };
 }
 

--- a/recipes-collection/util/importRecipeData.ts
+++ b/recipes-collection/util/importRecipeData.ts
@@ -78,9 +78,16 @@ export async function importRecipeData(
   if (recipeObject) {
     const { name, description, recipeIngredient, recipeInstructions } =
       recipeObject;
+
+    const newDescriptionSegments = [`*Imported from [${url}](${url})*`];
+    if (description) {
+      newDescriptionSegments.push(`\n\n---\n\n${description}`);
+    }
+
+    const newDescription = newDescriptionSegments.join("");
     const massagedData = {
       name,
-      description,
+      description: newDescription,
       ingredients: recipeIngredient?.map((ingredientString) => {
         const [massagedIngredient] = createIngredients(ingredientString);
         return massagedIngredient;

--- a/recipes-collection/util/parseIngredients.ts
+++ b/recipes-collection/util/parseIngredients.ts
@@ -1,35 +1,18 @@
-import { parseIngredient } from "parse-ingredient";
-import { Ingredient } from "../controller/types";
-import { formatQuantity } from "format-quantity";
-
 export function createIngredients(input: string) {
-  return parseIngredient(input).map(
-    ({ quantity, unitOfMeasure, description }) => {
-      const ingredientStringSegments = [];
-
-      if (quantity) {
-        const formattedQuantity = formatQuantity(quantity);
-        if (formattedQuantity) {
-          ingredientStringSegments.push(
-            `<Multiplyable baseNumber="${formattedQuantity}" />`,
-          );
-        } else {
-          ingredientStringSegments.push(quantity);
-        }
+  return input
+    .split(/\n+/)
+    .map((inputLine) => {
+      const trimmedInputLine = inputLine.trim();
+      if (trimmedInputLine) {
+        const multiplyableIngredient = trimmedInputLine.replace(
+          /[0-9]+(?:\/[0-9]+|(?: and)? [0-9]+\/[0-9]+|\.[0-9]+)?/g,
+          (match) => {
+            const normalizedMatch = match.replace(" and", "");
+            return `<Multiplyable baseNumber="${normalizedMatch}" />`;
+          },
+        );
+        return { ingredient: multiplyableIngredient };
       }
-
-      if (unitOfMeasure) {
-        ingredientStringSegments.push(unitOfMeasure);
-      }
-
-      if (description) {
-        ingredientStringSegments.push(description);
-      }
-
-      const massagedIngredient: Ingredient = {
-        ingredient: ingredientStringSegments.join(" "),
-      };
-      return massagedIngredient;
-    },
-  );
+    })
+    .filter(Boolean);
 }

--- a/recipes-collection/util/parseIngredients.ts
+++ b/recipes-collection/util/parseIngredients.ts
@@ -1,3 +1,5 @@
+import { Ingredient } from "../controller/types";
+
 export function createIngredients(input: string) {
   return input
     .split(/\n+/)
@@ -14,5 +16,5 @@ export function createIngredients(input: string) {
         return { ingredient: multiplyableIngredient };
       }
     })
-    .filter(Boolean);
+    .filter(Boolean) as Ingredient[];
 }

--- a/recipes-collection/util/parseIngredients.ts
+++ b/recipes-collection/util/parseIngredients.ts
@@ -5,11 +5,29 @@ import { formatQuantity } from "format-quantity";
 export function createIngredients(input: string) {
   return parseIngredient(input).map(
     ({ quantity, unitOfMeasure, description }) => {
-      const formattedQuantity = quantity ? formatQuantity(quantity) : undefined;
+      const ingredientStringSegments = [];
+
+      if (quantity) {
+        const formattedQuantity = formatQuantity(quantity);
+        if (formattedQuantity) {
+          ingredientStringSegments.push(
+            `<Multiplyable baseNumber="${formattedQuantity}" />`,
+          );
+        } else {
+          ingredientStringSegments.push(quantity);
+        }
+      }
+
+      if (unitOfMeasure) {
+        ingredientStringSegments.push(unitOfMeasure);
+      }
+
+      if (description) {
+        ingredientStringSegments.push(description);
+      }
+
       const massagedIngredient: Ingredient = {
-        quantity: formattedQuantity || undefined,
-        unit: unitOfMeasure || undefined,
-        ingredient: description,
+        ingredient: ingredientStringSegments.join(" "),
       };
       return massagedIngredient;
     },

--- a/website/package.json
+++ b/website/package.json
@@ -29,7 +29,6 @@
     "markdown-to-jsx": "^7.4.1",
     "netlify-cli": "^17.17.1",
     "next": "14.1.1",
-    "parse-ingredient": "^1.2.0",
     "react": "^18",
     "react-dom": "^18",
     "recipes-collection": "^1.0.0",


### PR DESCRIPTION
This PR overhauls the ingredient multiplying feature to use React Context to keep track of and propagate the multiplier value to all interested components.

We also introduce a `Multiplyable` custom component, which can be used in both ingredients and instructions. The `baseNumber` prop takes a string or number as input and displays a fraction string that is multiplied by the current multiplier context value.

Ingredients are changed to just be the "ingredient" string with a "Multiplyable" component on the amount number. Unit conversions can be added through this component later on.

A new test is added for the multiplying feature in general, which wasn't present before.