### PR TITLE
Parse vulgar fractions in imports/pastes

### DIFF
--- a/editor/cypress/e2e/new-recipe.cy.ts
+++ b/editor/cypress/e2e/new-recipe.cy.ts
@@ -62,6 +62,12 @@ describe("New Recipe View", () => {
             `<Multiplyable baseNumber="1" /> cup water ((for the dashi packet))`,
           );
 
+          // Verify vulgar fraction ingredient
+          cy.get('[name="ingredients[5].ingredient"]').should(
+            "have.value",
+            `<Multiplyable baseNumber="1/2" />  onion ((<Multiplyable baseNumber="4" /> oz, <Multiplyable baseNumber="113" /> g))`,
+          );
+
           // Verify first instruction, which is a simple step
           cy.get('[name="instructions[0].type"]').should("have.value", "step");
           cy.get('[name="instructions[0].name"]').should("have.value", "");

--- a/editor/cypress/e2e/new-recipe.cy.ts
+++ b/editor/cypress/e2e/new-recipe.cy.ts
@@ -33,6 +33,62 @@ describe("New Recipe View", () => {
         cy.checkNamesInOrder([newRecipeTitle]);
       });
 
+      it("should be able to paste ingredients", () => {
+        cy.findByRole("heading", { name: "New Recipe" });
+
+        const newRecipeTitle = "My New Recipe";
+
+        cy.findAllByLabelText("Name").first().clear();
+        cy.findAllByLabelText("Name").first().type(newRecipeTitle);
+
+        cy.findByText("Paste Ingredients").click();
+        cy.findByTitle("Ingredients Paste Area").type(
+          `
+1 cup water ((for the dashi packet))
+1  dashi packet
+2 tsp sugar
+2 Tbsp mirin
+2 Tbsp soy sauce
+½  onion ((4 oz 113 g))
+1  green onion/scallion ((for garnish))
+3  large eggs (50 g each w/o shell)
+2  tonkatsu
+2 servings cooked Japanese short-grain rice ((typically 1⅔ cups (250 g) per donburi serving))
+`,
+        );
+
+        cy.findByText("Import Ingredients").click();
+
+        // Verify first ingredient
+        cy.get('[name="ingredients[0].ingredient"]').should(
+          "have.value",
+          `<Multiplyable baseNumber="1" /> cup water ((for the dashi packet))`,
+        );
+
+        // Verify vulgar fraction ingredient
+        cy.get('[name="ingredients[5].ingredient"]').should(
+          "have.value",
+          `<Multiplyable baseNumber="1/2" />  onion ((<Multiplyable baseNumber="4" /> oz <Multiplyable baseNumber="113" /> g))`,
+        );
+
+        cy.findByText("Submit").click();
+
+        cy.findByRole("heading", { name: newRecipeTitle });
+
+        cy.findByText("1 cup water ((for the dashi packet))");
+        cy.findByText("1 dashi packet");
+        cy.findByText("2 tsp sugar");
+        cy.findByText("2 Tbsp mirin");
+        cy.findByText("2 Tbsp soy sauce");
+        cy.findByText("1/2 onion ((4 oz 113 g))");
+        cy.findByText("1 green onion/scallion ((for garnish))");
+        cy.findByText("3 large eggs (50 g each w/o shell)");
+        cy.findByText("2 tonkatsu");
+        cy.findByText(
+          "2 servings cooked Japanese short-grain rice ((typically 4 cups (250 g) per donburi serving))",
+        );
+      });
+
       it("should be able to import a recipe", () => {
         const baseURL = Cypress.config().baseUrl;
         const testURL = "/uploads/katsudon.html";

--- a/recipes-collection/components/Form/Ingredients/index.tsx
+++ b/recipes-collection/components/Form/Ingredients/index.tsx
@@ -30,11 +30,14 @@ export function IngredientsListInput({
   const [{ values }, dispatch] = useKeyList<Ingredient>(defaultValue);
   const importTextareaRef = useRef<HTMLTextAreaElement>(null);
   const detailsRef = useRef<HTMLDetailsElement>(null);
+  const ingredientsPasteId = "ingredients-paste-area";
   return (
     <FieldWrapper label={label} id={id}>
       <details ref={detailsRef}>
-        <summary>Paste</summary>
+        <summary>Paste Ingredients</summary>
         <textarea
+          title="Ingredients Paste Area"
+          id={ingredientsPasteId}
           ref={importTextareaRef}
           className={clsx(baseInputStyle, "w-full h-36")}
         />

--- a/recipes-collection/components/Form/Instructions/index.tsx
+++ b/recipes-collection/components/Form/Instructions/index.tsx
@@ -176,11 +176,14 @@ export function InstructionsListInput({
   const [{ values }, dispatch] = useKeyList<InstructionEntry>(defaultValue);
   const importTextareaRef = useRef<HTMLTextAreaElement>(null);
   const detailsRef = useRef<HTMLDetailsElement>(null);
+  const instructionsPasteId = "instructions-paste-area";
   return (
     <FieldWrapper label={label} id={id}>
       <details ref={detailsRef}>
-        <summary>Paste</summary>
+        <summary>Paste Instructions</summary>
         <textarea
+          title="Instructions Paste Area"
+          id={instructionsPasteId}
           ref={importTextareaRef}
           className={clsx(baseInputStyle, "w-full h-36")}
         />
@@ -198,7 +201,7 @@ export function InstructionsListInput({
               }
             }}
           >
-            Import Ingredients
+            Import Instructions
           </Button>
         </div>
       </details>

--- a/recipes-collection/util/parseIngredients.ts
+++ b/recipes-collection/util/parseIngredients.ts
@@ -1,4 +1,4 @@
-import { Ingredient } from "../controller/types";
+import type { Ingredient } from "../controller/types";
 
 export function createIngredients(input: string) {
   return input
@@ -7,7 +7,7 @@ export function createIngredients(input: string) {
       const trimmedInputLine = inputLine
         .trim()
         .normalize("NFKD")
-        .replace(/⁄/g, "/");
+        .replaceAll("⁄", "/");
       if (trimmedInputLine) {
         const multiplyableIngredient = trimmedInputLine.replace(
           /[0-9]+(?:\/[0-9]+|(?: and)? [0-9]+\/[0-9]+|\.[0-9]+)?/g,

--- a/recipes-collection/util/parseIngredients.ts
+++ b/recipes-collection/util/parseIngredients.ts
@@ -4,7 +4,10 @@ export function createIngredients(input: string) {
   return input
     .split(/\n+/)
     .map((inputLine) => {
-      const trimmedInputLine = inputLine.trim();
+      const trimmedInputLine = inputLine
+        .trim()
+        .normalize("NFKD")
+        .replace(/⁄/g, "/");
       if (trimmedInputLine) {
         const multiplyableIngredient = trimmedInputLine.replace(
           /[0-9]+(?:\/[0-9]+|(?: and)? [0-9]+\/[0-9]+|\.[0-9]+)?/g,


### PR DESCRIPTION
This PR adds the ability for "vulgar fractions" (e.g. ½) to be parsed as normal fractions. With this implementation, we assume that we want to convert all fractions to use normal / (e.g. "1/2") in order to be parsed correctly by the `Multiplyable`-finding regex.

This PR adds an explicit test for this behavior into the existing import text, as well as adding a whole new test for paste imports along with some minor UI changes to distinguish the buttons for the tests and hopefully users too.